### PR TITLE
retry `cmd.Exec`

### DIFF
--- a/pkg/spark/spark_test.go
+++ b/pkg/spark/spark_test.go
@@ -14,7 +14,9 @@ limitations under the License.
 package spark
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -74,5 +76,18 @@ func TestSpark(t *testing.T) {
 			"--master=k8s://http://localhost:8000",
 			"--status=namespace:name",
 		}, args)
+	})
+
+	t.Run("retry works", func(t *testing.T) {
+		try := 0
+		fn := func() error {
+			if try >= 2 {
+				return nil
+			}
+			try++
+			return fmt.Errorf("error in fn")
+		}
+		require.NoError(t, retry(3, 1*time.Nanosecond, 2, 1*time.Second, fn))
+		require.Greater(t, try, 1)
 	})
 }


### PR DESCRIPTION
- implemented a retry mechanism for retrying the call to cmd.Exec()
- use a simple exponential backoff implementation, which multiplies the current delay until `maxWait` is reached
- the call to `s.exec` already runs in a go-routine, which allows us to use time.Sleep without blocking any other logic.

The purpose of this retry mechanism is circumvent issues with the kubernetes API.